### PR TITLE
deprecate: remove PHP 7.x, 8.0 and 8.1 from active builds and update docs

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         variant: [v1, v2]
-        php-version: ['8.3', '8.1']
+        php-version: ['8.3', '8.2']
         php-type: [fpm, cli]
         php-base: [alpine, bookworm]
         exclude:
@@ -224,20 +224,12 @@ jobs:
       fail-fast: false
       matrix:
         variant: [v1, v2]
-        php-version: ['8.3', '8.2', '8.1', '7']
+        php-version: ['8.3', '8.2']
         php-type: [fpm, cli, apache]
-        php-base: [alpine, bookworm, bullseye]
+        php-base: [alpine, bookworm]
         exclude:
           - php-type: apache
             php-base: alpine
-          - php-version: '7'
-            php-base: bookworm
-          - php-version: '8.3'
-            php-base: bullseye
-          - php-version: '8.2'
-            php-base: bullseye
-          - php-version: '8.1'
-            php-base: bullseye
     
     name: publish-${{ matrix.variant }}-${{ matrix.php-version }}-${{ matrix.php-type }}-${{ matrix.php-base }}
     

--- a/.github/workflows/docker-image.v1.yml
+++ b/.github/workflows/docker-image.v1.yml
@@ -13,19 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         php-type: [cli, fpm, apache]
-        php-version: ['8.3', '8.2', '8.1', '7']
-        php-base-os: [bullseye, bookworm, alpine]
+        php-version: ['8.3', '8.2']
+        php-base-os: [bookworm, alpine]
         exclude:
           - php-type: apache
             php-base-os: alpine
-          - php-version: '7'
-            php-base-os: bookworm
-          - php-version: '8.3'
-            php-base-os: bullseye
-          - php-version: '8.2'
-            php-base-os: bullseye
-          - php-version: '8.1'
-            php-base-os: bullseye
 
     steps:
     - name: Checkout source

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Multi-architecture PHP Docker images with extensive extensions for modern web de
 [![Docker Pulls](https://img.shields.io/docker/pulls/kingpin/php-docker)](https://hub.docker.com/r/kingpin/php-docker)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/kingpin/php-docker/docker-ci.yml?branch=main)](https://github.com/kingpin/php-docker/actions/workflows/docker-ci.yml)
 
+> **⚠️ Deprecation Notice**: PHP 7.x and 8.1 builds are **no longer published** as of January 2025. Existing images remain available in registries for backwards compatibility. See [Deprecated Versions](#deprecated-versions) below.
+
 ## 🎯 Which Image Should I Use?
 
 **New projects or need process supervision?** → Use **v2** images (e.g., `8.3-fpm-alpine-v2`)  
@@ -15,7 +17,7 @@ See [v1 vs v2 comparison](#v1-vs-v2-comparison) below for details.
 ## Features
 
 - **Multi-Architecture Support**: Works on `amd64`, `arm64/aarch64` and `arm32v7/armhf` platforms
-- **Multiple PHP Versions**: PHP 7.x (deprecated), 8.1, 8.2, and 8.3
+- **Multiple PHP Versions**: PHP 8.2 and 8.3 (actively built); PHP 7.x and 8.1 deprecated
 - **Multiple Server Types**: CLI, FPM, and Apache
 - **Base OS Options**: Alpine (lightweight) and Debian (Bookworm/Bullseye)
 - **Extensive Extensions**: 30+ PHP extensions pre-installed
@@ -444,6 +446,25 @@ COPY custom-php.ini /usr/local/etc/php/conf.d/
 # Install additional extensions if needed
 RUN install-php-extensions swoole
 ```
+
+## Deprecated Versions
+
+The following PHP versions are **no longer actively built** but remain available in registries for backwards compatibility:
+
+### PHP 7.x (End of Life)
+- All PHP 7.x images (7.4 and earlier)
+- Last published: January 2025
+- Available tags: `7-cli-alpine`, `7-fpm-alpine`, `7-apache-bullseye`, etc.
+
+### PHP 8.1 (End of Active Support)
+- All PHP 8.1 images
+- Last published: January 2025
+- Available tags: `8.1-cli-alpine`, `8.1-fpm-alpine`, `8.1-apache-bookworm`, etc.
+
+**Migration Path:**
+- Upgrade to PHP 8.2 or 8.3 for continued security updates and new builds
+- See [migration guide](docs/migration.md) for upgrade assistance
+- Existing images will remain available in Docker Hub, GHCR, and Quay.io
 
 ## 🏗️ Architecture Diagram
 ```

--- a/README.md
+++ b/README.md
@@ -321,23 +321,30 @@ Both v1 and v2 variants are available for all combinations below:
 | 8.2         | FPM    | Alpine    | `8.2-fpm-alpine`       | `8.2-fpm-alpine-v2`        |
 | 8.2         | FPM    | Bookworm  | `8.2-fpm-bookworm`     | `8.2-fpm-bookworm-v2`      |
 | 8.2         | Apache | Bookworm  | `8.2-apache-bookworm`  | `8.2-apache-bookworm-v2`   |
-| 8.1         | CLI    | Alpine    | `8.1-cli-alpine`       | `8.1-cli-alpine-v2`        |
-| 8.1         | CLI    | Bookworm  | `8.1-cli-bookworm`     | `8.1-cli-bookworm-v2`      |
-| 8.1         | FPM    | Alpine    | `8.1-fpm-alpine`       | `8.1-fpm-alpine-v2`        |
-| 8.1         | FPM    | Bookworm  | `8.1-fpm-bookworm`     | `8.1-fpm-bookworm-v2`      |
-| 8.1         | Apache | Bookworm  | `8.1-apache-bookworm`  | `8.1-apache-bookworm-v2`   |
+
 
 > **Note:** PHP 8.1+ images are built on Bookworm (Debian 12). Bullseye tags redirect to Bookworm for PHP 8.1+.
 
 ### Deprecated Tags (v1 only)
 
-PHP 7.x images are available but no longer actively maintained:
+The following tags are deprecated and will not be built going forward, but remain available in registries for backwards compatibility:
 
-- `7-cli-bullseye`, `7-cli-alpine`
-- `7-fpm-bullseye`, `7-fpm-alpine`
-- `7-apache-bullseye`
+- PHP 7.x:
+  - `7-cli-bullseye`, `7-cli-alpine`
+  - `7-fpm-bullseye`, `7-fpm-alpine`
+  - `7-apache-bullseye`
 
-> **Important:** PHP 7.x has reached end-of-life. Please upgrade to PHP 8.1+ for security and performance.
+- PHP 8.0:
+  - `8-cli-bullseye`, `8-cli-alpine`
+  - `8-fpm-bullseye`, `8-fpm-alpine`
+  - `8-apache-bullseye`
+
+- PHP 8.1:
+  - `8.1-cli-bullseye`, `8.1-cli-bookworm`, `8.1-cli-alpine`
+  - `8.1-fpm-bullseye`, `8.1-fpm-bookworm`, `8.1-fpm-alpine`
+  - `8.1-apache-bullseye`, `8.1-apache-bookworm`
+
+> **Important:** These versions are deprecated. Please upgrade to PHP 8.2 or 8.3 for security and performance.
 
 ## 📊 Image Sizes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Multi-architecture PHP Docker images with extensive extensions for modern web de
 [![Docker Pulls](https://img.shields.io/docker/pulls/kingpin/php-docker)](https://hub.docker.com/r/kingpin/php-docker)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/kingpin/php-docker/docker-ci.yml?branch=main)](https://github.com/kingpin/php-docker/actions/workflows/docker-ci.yml)
 
-> **⚠️ Deprecation Notice**: PHP 7, 8 and 8.1 builds are **no longer published**. Existing images remain available in registries for backwards compatibility. See [Deprecated Versions](#deprecated-versions) below.
+> **⚠️ Deprecation Notice**: PHP 7.x, 8.0 and 8.1 builds are **no longer published**. Existing images remain available in registries for backwards compatibility. See [Deprecated Versions](#deprecated-versions) below.
 
 ## 🎯 Which Image Should I Use?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Multi-architecture PHP Docker images with extensive extensions for modern web de
 [![Docker Pulls](https://img.shields.io/docker/pulls/kingpin/php-docker)](https://hub.docker.com/r/kingpin/php-docker)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/kingpin/php-docker/docker-ci.yml?branch=main)](https://github.com/kingpin/php-docker/actions/workflows/docker-ci.yml)
 
-> **⚠️ Deprecation Notice**: PHP 7.x and 8.1 builds are **no longer published** as of January 2025. Existing images remain available in registries for backwards compatibility. See [Deprecated Versions](#deprecated-versions) below.
+> **⚠️ Deprecation Notice**: PHP 7, 8 and 8.1 builds are **no longer published**. Existing images remain available in registries for backwards compatibility. See [Deprecated Versions](#deprecated-versions) below.
 
 ## 🎯 Which Image Should I Use?
 
@@ -17,7 +17,7 @@ See [v1 vs v2 comparison](#v1-vs-v2-comparison) below for details.
 ## Features
 
 - **Multi-Architecture Support**: Works on `amd64`, `arm64/aarch64` and `arm32v7/armhf` platforms
-- **Multiple PHP Versions**: PHP 8.2 and 8.3 (actively built); PHP 7.x and 8.1 deprecated
+- **Multiple PHP Versions**: PHP 8.2 and 8.3 (actively built); PHP 7, 8 and 8.1 deprecated
 - **Multiple Server Types**: CLI, FPM, and Apache
 - **Base OS Options**: Alpine (lightweight) and Debian (Bookworm/Bullseye)
 - **Extensive Extensions**: 30+ PHP extensions pre-installed

--- a/docs/deprecated-images.md
+++ b/docs/deprecated-images.md
@@ -1,0 +1,203 @@
+# Deprecated PHP Docker Images
+
+This document lists PHP versions that are **no longer actively built** but remain available in container registries for backwards compatibility.
+
+## ⚠️ Important Notice
+
+- **No new builds** will be published for these versions
+- **No security updates** will be applied to these images
+- **Existing images remain available** for download from Docker Hub, GHCR, and Quay.io
+- **Migration is strongly recommended** for production workloads
+
+## Deprecated Versions
+
+### PHP 7.x (All Variants)
+
+**Status**: End of Life - No longer maintained by PHP project  
+**Last Build**: January 2025  
+**Reason**: PHP 7.4 reached end-of-life November 2022
+
+#### Available Tags (Legacy)
+
+**Alpine-based:**
+- `7-cli-alpine`
+- `7-fpm-alpine`
+- `7-cli-alpine-v2`
+- `7-fpm-alpine-v2`
+
+**Debian Bullseye-based:**
+- `7-cli-bullseye`
+- `7-fpm-bullseye`
+- `7-apache-bullseye`
+- `7-cli-bullseye-v2`
+- `7-fpm-bullseye-v2`
+- `7-apache-bullseye-v2`
+
+**Architectures**: linux/amd64, linux/arm64, linux/arm/v7
+
+### PHP 8.1 (All Variants)
+
+**Status**: End of Active Support (security-only updates until Nov 2025)  
+**Last Build**: January 2025  
+**Reason**: Focus maintenance on PHP 8.2+ for better resource allocation
+
+#### Available Tags (Legacy)
+
+**Alpine-based:**
+- `8.1-cli-alpine`
+- `8.1-fpm-alpine`
+- `8.1-cli-alpine-v2`
+- `8.1-fpm-alpine-v2`
+
+**Debian Bookworm-based:**
+- `8.1-cli-bookworm`
+- `8.1-fpm-bookworm`
+- `8.1-apache-bookworm`
+- `8.1-cli-bookworm-v2`
+- `8.1-fpm-bookworm-v2`
+- `8.1-apache-bookworm-v2`
+
+**Architectures**: linux/amd64, linux/arm64, linux/arm/v7
+
+## Migration Recommendations
+
+### From PHP 7.x → PHP 8.2 or 8.3
+
+**Breaking Changes to Consider:**
+- Deprecated features removed in PHP 8.0+
+- Stricter type handling
+- Changes to error reporting
+- Removed legacy extensions
+
+**Steps:**
+1. Review [PHP 8 migration guide](https://www.php.net/manual/en/migration80.php)
+2. Test your application locally with PHP 8.2 or 8.3
+3. Update dependencies in `composer.json`
+4. Run automated tests
+5. Update Docker image tags
+
+**Example:**
+```bash
+# Old (deprecated)
+docker pull kingpin/php-docker:7-fpm-alpine
+
+# New (recommended)
+docker pull kingpin/php-docker:8.3-fpm-alpine
+```
+
+### From PHP 8.1 → PHP 8.2 or 8.3
+
+**Breaking Changes:**
+- PHP 8.2: Deprecated dynamic properties
+- PHP 8.3: More readonly class features
+
+**Steps:**
+1. Review [PHP 8.2 migration guide](https://www.php.net/manual/en/migration82.php) or [PHP 8.3 guide](https://www.php.net/manual/en/migration83.php)
+2. Update image tags in your deployment manifests
+3. Test thoroughly in staging environment
+4. Deploy to production
+
+**Example:**
+```bash
+# Old (deprecated)
+docker pull kingpin/php-docker:8.1-fpm-alpine
+
+# New (recommended)
+docker pull kingpin/php-docker:8.3-fpm-alpine
+```
+
+### Docker Compose Migration
+
+```yaml
+# Before (deprecated)
+services:
+  app:
+    image: kingpin/php-docker:8.1-fpm-alpine
+
+# After (recommended)
+services:
+  app:
+    image: kingpin/php-docker:8.3-fpm-alpine
+```
+
+### Kubernetes/Helm Migration
+
+```yaml
+# Before (deprecated)
+containers:
+  - name: app
+    image: kingpin/php-docker:8.1-fpm-alpine
+
+# After (recommended)
+containers:
+  - name: app
+    image: kingpin/php-docker:8.3-fpm-alpine
+```
+
+## Long-Term Availability
+
+### Registry Retention
+
+These deprecated images will remain available **indefinitely** in the following registries:
+- **Docker Hub**: hub.docker.com/r/kingpin/php-docker
+- **GitHub Container Registry**: ghcr.io/kingpin/php-docker
+- **Quay.io**: quay.io/kingpinx1/php-docker
+
+### Pulling Deprecated Images
+
+You can continue to pull these images as normal:
+
+```bash
+# PHP 7.x example
+docker pull kingpin/php-docker:7-fpm-alpine
+
+# PHP 8.1 example
+docker pull kingpin/php-docker:8.1-fpm-alpine
+```
+
+### Security Considerations
+
+**Important**: Deprecated images will NOT receive:
+- Security patches for PHP vulnerabilities
+- Updates to bundled system packages
+- Updates to PHP extensions
+- Bug fixes
+
+**For production use**, we strongly recommend migrating to actively supported versions (PHP 8.2 or 8.3).
+
+## Support Policy
+
+- **Active Builds**: PHP 8.2 and 8.3 (receive regular updates)
+- **Deprecated**: PHP 7.x and 8.1 (images frozen, no updates)
+- **Removed**: None (all previously published images remain available)
+
+## Image Digests (Last Published)
+
+For reproducible builds, you can pin to specific digests. Contact the maintainer or check registry APIs for exact digest values of the last published builds.
+
+Example of digest pinning:
+```bash
+# Pin to specific digest (immutable)
+docker pull kingpin/php-docker@sha256:abcdef1234567890...
+```
+
+## Questions or Issues?
+
+If you need assistance migrating from deprecated versions:
+
+1. Check the [migration guide](migration.md)
+2. Review [troubleshooting guide](troubleshooting.md)
+3. Open an issue on GitHub with:
+   - Current deprecated version you're using
+   - Target version you want to migrate to
+   - Specific migration challenges
+
+## Timeline
+
+- **November 2024**: Announcement of deprecation plan
+- **January 2025**: Last builds for PHP 7.x and 8.1
+- **Ongoing**: Images remain available in registries indefinitely
+
+---
+
+Last updated: January 2025

--- a/docs/deprecated-images.md
+++ b/docs/deprecated-images.md
@@ -2,7 +2,7 @@
 
 This document lists PHP versions that are **no longer actively built** but remain available in container registries for backwards compatibility.
 
-## ⚠️ Important Notice
+## ℹ️ Important Notice
 
 - **No new builds** will be published for these versions
 - **No security updates** will be applied to these images

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,8 @@
 
 This guide helps you migrate from v1 (legacy) to v2 (modern) PHP Docker images.
 
+> **ℹ️ Note on Deprecated Versions**: PHP 7.x and 8.1 are no longer actively built. If you're using these versions, please also review the [deprecated images guide](deprecated-images.md) for upgrade paths to PHP 8.2 or 8.3.
+
 ## Should You Migrate?
 
 **Consider migrating to v2 if:**


### PR DESCRIPTION
- Remove PHP 7.x, 8.0 and 8.1 from active CI build/publish matrices and update documentation to mark them as deprecated.
- Keep previously published images available in registries (Docker Hub / GHCR / Quay) for backwards compatibility; this PR only stops active building/publishing of those versions.
- Branch: deprecate-php-7-8.1