### PR TITLE
chore(deps): improve dependabot config with grouping and schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,24 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"
+      security-actions:
+        patterns:
+          - "aquasecurity/*"
+          - "github/codeql-action*"
+      github-actions:
+        patterns:
+          - "actions/*"
+          - "gautamkrishnar/*"
+          - "gaurav-nelson/*"
+          - "DavidAnson/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
           - "docker/*"
       security-actions:
         patterns:
-          - "aquasecurity/*"
+          - "aquasecurity/trivy-action"
           - "github/codeql-action*"
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

- Switch schedule from `daily` to `weekly` (Monday 04:00 UTC) — action releases are infrequent, daily was unnecessary noise
- Set `open-pull-requests-limit: 10` — default of 5 would be exhausted by the 10+ actions in use
- Add `commit-message.prefix: "chore(deps)"` for conventional commit format
- Add `groups` to batch related PRs:
  - `docker-actions` — all `docker/*` actions (buildx, build-push, qemu, login)
  - `security-actions` — `aquasecurity/trivy-action` + `github/codeql-action`
  - `github-actions` — `actions/*`, `gautamkrishnar/*`, `gaurav-nelson/*`, `DavidAnson/*`

## Test plan

- [ ] Verify config is valid via GitHub's "Insights > Dependency graph > Dependabot" tab after merge
- [ ] Confirm next Monday Dependabot run produces grouped PRs instead of individual ones