### PR TITLE
ci: scheduled prune of untagged GHCR staging digests

### DIFF
--- a/.github/workflows/ghcr-prune.yml
+++ b/.github/workflows/ghcr-prune.yml
@@ -1,0 +1,40 @@
+name: GHCR untagged prune
+
+# Per-arch staging digests pushed during docker-ci.yml accumulate as untagged
+# versions on the ghcr.io/kingpin/php-docker package. The cleanup action's
+# algorithm removes children of live manifest lists from the working set
+# before applying any deletion rule, so the per-arch digests referenced by
+# current tags are safe even though they appear untagged in the GHCR UI.
+#
+# older-than: 28d keeps a buffer wide enough to survive 2-3 weeks without a
+# successful build (weekly schedule + ad-hoc dispatches).
+#
+# dry-run: true initially — verify the planned deletions in a run summary
+# before flipping to false.
+
+on:
+  schedule:
+    - cron: '0 5 * * 3'  # Wednesday 05:00 UTC, day after the weekly build
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (list deletions without performing them)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: ghcr-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          package: php-docker
+          delete-untagged: true
+          older-than: 28d
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || true }}

--- a/.github/workflows/ghcr-prune.yml
+++ b/.github/workflows/ghcr-prune.yml
@@ -37,4 +37,4 @@ jobs:
           package: php-docker
           delete-untagged: true
           older-than: 28d
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || true }}
+          dry-run: ${{ github.event_name != 'workflow_dispatch' || inputs.dry-run }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ghcr-prune.yml`: weekly scheduled prune (Wed 05:00 UTC, day after the weekly build) of untagged versions on the `ghcr.io/kingpin/php-docker` package.
- Uses [`dataaxiom/ghcr-cleanup-action@v1`](https://github.com/dataaxiom/ghcr-cleanup-action). Its cleanup algorithm removes children of live manifest lists from the working set before applying any deletion rule, so the per-arch digests referenced by current tags are not at risk even though they appear untagged.
- `older-than: 28d` keeps a comfortable buffer if the weekly build is red for a week or two.
- Ships with `dry-run: true` so the first scheduled run logs intended deletions without executing them. Manual `workflow_dispatch` exposes a `dry-run` boolean (defaults to true).

Closes #39

## Test plan
- [ ] Trigger via `workflow_dispatch` with the default `dry-run: true` and confirm the run summary lists only stale untagged digests (no children of live tagged manifest lists).
- [ ] Verify a fresh `docker pull ghcr.io/kingpin/php-docker:<tag>` still resolves after the dry run (no-op, but sanity check).
- [ ] Flip the workflow default `dry-run` to `false` in a follow-up commit once the dry-run output looks correct.
- [ ] After the first real prune, re-pull a representative tag from each registry (Docker Hub, GHCR, Quay) and confirm the manifest list still resolves all platforms.